### PR TITLE
編集が反映されなかったり、違うものが修正されるバグの解消

### DIFF
--- a/Assets/Scripts/InputZoomUrl/DeleteZoomUrl.cs
+++ b/Assets/Scripts/InputZoomUrl/DeleteZoomUrl.cs
@@ -42,6 +42,10 @@ namespace InputZoomUrl
             {
                 SetNewListner(clonedButtons[index], index);
             }
+
+            // BackButtonの挙動を変更
+            backButton.onClick.RemoveAllListeners();
+            backButton.onClick.AddListener(() => Back());
         }
         
         // 引数で受け取ったUIオブジェクトを全てactiveの値にする

--- a/Assets/Scripts/InputZoomUrl/EditZoomUrl.cs
+++ b/Assets/Scripts/InputZoomUrl/EditZoomUrl.cs
@@ -43,6 +43,10 @@ namespace InputZoomUrl
             {
                 SetNewListner(clonedButtons[index], index);
             }
+            
+            // BackButtonの挙動を変更
+            backButton.onClick.RemoveAllListeners();
+            backButton.onClick.AddListener(() => Back());
         }
 
         // 引数で受け取ったUIオブジェクトを全てactiveの値にする
@@ -86,6 +90,7 @@ namespace InputZoomUrl
             inputZoomUrlField.text = data.Item2;
             
             // Edit Saveボタンにリスナーを登録
+            editSaveButton.onClick.RemoveAllListeners();
             editSaveButton.onClick.AddListener(() => EditSaveOnClick(n));
         }
 


### PR DESCRIPTION
- 原因は以下の2点です
  - BackButtonにDeleteZoomUrlのBack関数が登録されており、EditButtonを押してからBackButtonを押しても、Deleteを押してからBackButtonを押した際の挙動しかされない
    - EditButtonまたはDeleteButtonを押した際に、正しいイベントリスナーが登録されるように変更
  - EditButtonを押して、変更したいRoomのボタンを押したとき、EditSaveButtonにイベントリスナーが登録されるが、それを適切に削除していなかったので、再び同じ動きをユーザーがした際に、EditSaveButtonに以前のイベントリスナーが登録されていて、このため指定したのとは違うRoomのデータが変更されてしまっていた
    - EditSaveButtonにイベントリスナーが登録する際に、すでに登録されているイベントリスナーを全て削除するように変更